### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = false
+
+[to]
+indent_style = space
+indent_size = 1


### PR DESCRIPTION
As most editors understand the .editorconfig format, it makes sense to
add one to avoid issues with indentation and other formatting mistakes.